### PR TITLE
Add individually configurable throttle groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ When a group reaches its limit and as long as it is not reset, a warning
 message with the current log rate of the group is emitted repeatedly. This is
 the delay between every repetition.
 
+#### group\_override
+
+Allows overriding the defaults per group. To use this value, configure a JSON
+object with the group name value as the object name, and the above group_*
+parameters as entries. For example:
+```
+group_override {"group_bucket_1": {
+                  "group_bucket_period_s": 1,
+                  "group_bucket_limit": 7,
+                  "group_drop_logs": true
+                }}
+```
+This will configure an override for a group name of `group_bucket_1` with
+different throttling limits than others.  
+
 ## License
 
 Apache License, Version 2.0

--- a/test/fluent/plugin/filter_throttle_test.rb
+++ b/test/fluent/plugin/filter_throttle_test.rb
@@ -61,6 +61,44 @@ describe Fluent::Plugin::ThrottleFilter do
       assert_equal(5, groups["b"].size)
     end
 
+    it 'rejects override configurations with invalid values' do
+      assert_raises { create_driver <<~CONF
+        group_key "group"
+        group_bucket_period_s 1
+        group_bucket_limit 5
+        group_override {"group_bucket_1":{
+          "group_bucket_period_s": -1,
+          "group_bucket_limit": 7,
+          "group_drop_logs": true
+        }}
+      CONF
+      }
+    end
+
+    it 'throttles with different rates in override configs' do
+      driver = create_driver <<~CONF
+        group_key "group"
+        group_bucket_period_s 1
+        group_bucket_limit 5
+        group_override {"group_bucket_1":{
+          "group_bucket_period_s": 1,
+          "group_bucket_limit": 7,
+          "group_drop_logs": true
+        }}
+      CONF
+
+      driver.run(default_tag: "test") do
+        driver.feed([[event_time, {"msg": "test", "group": "a"}]] * 10)
+        driver.feed([[event_time, {"msg": "test", "group": "b"}]] * 10)
+        driver.feed([[event_time, {"msg": "test", "group": "group_bucket_1"}]] * 10)
+      end
+
+      groups = driver.filtered_records.group_by { |r| r[:group] }
+      assert_equal(5, groups["a"].size)
+      assert_equal(5, groups["b"].size)
+      assert_equal(7, groups["group_bucket_1"].size)
+    end
+
     it 'allows composite group keys' do
       driver = create_driver <<~CONF
         group_key "group1,group2"

--- a/test/fluent/plugin/filter_throttle_test.rb
+++ b/test/fluent/plugin/filter_throttle_test.rb
@@ -155,6 +155,22 @@ describe Fluent::Plugin::ThrottleFilter do
       ], messages_per_minute
     end
 
+    it 'removes lru groups after 2*period' do
+      driver = create_driver <<~CONF
+        group_key "group"
+        group_bucket_period_s 2
+        group_bucket_limit 6
+        group_reset_rate_s 2
+      CONF
+
+      driver.run(default_tag: "test") do
+        Time.stubs(now: Time.at(1))
+        driver.feed([[event_time, {"msg": "test", "group": "a"}]] * 2)
+        Time.stubs(now: Time.at(10))
+        driver.feed([[event_time, {"msg": "test", "group": "b"}]] * 2)
+      end
+      #  TODO: Figure out how to assert the group was removed from the private variable
+    end
 
     it 'does not throttle when in log only mode' do
       driver = create_driver <<~CONF


### PR DESCRIPTION
Added a group_override config parameter which allows setting different throttle limits per group.